### PR TITLE
Update workflow to include pull request triggers and group-runners

### DIFF
--- a/.github/workflows/boletim-diario.yml
+++ b/.github/workflows/boletim-diario.yml
@@ -2,13 +2,19 @@ name: boletim-diario
 on: 
     schedule:
       - cron: '55 12 * * *'
+    pull_request:
+        types: [opened, synchronize, reopened]
+        
     workflow_dispatch:
 permissions:
   contents: read
   issues: write
 jobs:
+
   boletim-diario:
-    runs-on: ubuntu-latest
+    runs-on: 
+        group: codaqui-runners
+        labels: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v3
 
@@ -60,5 +66,6 @@ jobs:
           reactions: '+1'
           body: |
             ${{ env.SCRIPT_CONTEUDO }}
+
 
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for `boletim-diario` to enhance automation and optimize runner usage. The main changes enable the workflow to trigger on pull request events and switch execution to self-hosted runners for improved control and resource management.

Workflow trigger updates:
* Added support for triggering the workflow on pull request events (`opened`, `synchronize`, `reopened`), in addition to the existing schedule and manual dispatch options.

Runner configuration changes:
* Updated the workflow to run on self-hosted runners by specifying the `group: codaqui-runners` and `labels: [self-hosted, linux]`, instead of the default `ubuntu-latest` GitHub-hosted runner.